### PR TITLE
Network name must be bridge

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -28,3 +28,5 @@ services:
       
 networks:
   kademlia_network:
+    external:
+      name: bridge


### PR DESCRIPTION
It seems like I made a mistake, and the swarm won't start without these two lines.

If someone understands the underlying cause and what should be done instead, please tell me.