### PR TITLE
Mock of a bootstrap procedure

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,4 +12,7 @@ FROM alpine:latest
 #
 # $ docker build . -t kadlab
 
+RUN apk add --no-cache tmux
+
 COPY ping2container.sh .
+COPY mock-kademlia.sh ./kademlia

--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -1,0 +1,28 @@
+#!/bin/bash
+
+cids=`docker ps | grep kadstack_kademliaNodes | grep Up | cut -d\  -f1 | sort`
+
+# Determine active container's Containter IDs
+
+echo --- Detection phase ------
+i=0
+for cid in $cids
+do
+cidip[i]=`docker inspect --format='{{.ID}}:{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}' $cid`
+cip[i]=`echo ${cidip[i]} | cut -d\: -f2`
+echo ${cidip[i]}
+i=$(($i+1))
+done
+echo $i running nodes.
+
+echo
+
+echo --- Bootstrap network -----------------------------------------------------
+echo
+for cide in ${cidip[@]}
+do
+eid=`echo $cide | cut -d\: -f1 | cut -c-8`
+cmd="/usr/bin/tmux new-session -d './kademlia ${cip[0]}:9000'"
+res=`docker exec $eid sh -c "${cmd}"`
+echo $eid: $cmd
+done

--- a/docker/mock-kademlia.sh
+++ b/docker/mock-kademlia.sh
@@ -1,0 +1,6 @@
+#/bin/sh
+
+echo "Mock Kademlia"
+# Let's write a file so that we can see that everything runs
+echo "Kademlia was here" > kademlia.log
+


### PR DESCRIPTION
Here's an example of how starting the network could look, heavily plagiarizing `ping2host.sh`.

By starting the containers and then starting the nodes we are aware of all available IPs.

Resolves #11