### PR TITLE
Add store/fetch and CLI

### DIFF
--- a/docker/bootstrap.sh
+++ b/docker/bootstrap.sh
@@ -22,7 +22,7 @@ echo
 for cide in ${cidip[@]}
 do
 eid=`echo $cide | cut -d\: -f1 | cut -c-8`
-cmd="/usr/bin/tmux new-session -d './kademlia ${cip[0]}:9000'"
+cmd="/usr/bin/tmux new-session -d './kademlia ${cip[0]}:9000 > last.log'"
 res=`docker exec $eid sh -c "${cmd}"`
 echo $eid: $cmd
 done

--- a/labCode/kademlia.go
+++ b/labCode/kademlia.go
@@ -1,5 +1,12 @@
 package d7024e
 
+import (
+    "bufio"
+    "os"
+    "strings"
+    "sync"
+)
+
 type Kademlia struct {
     network Network
 }
@@ -14,23 +21,68 @@ func NewKademlia(ip string, port uint16, peer string) Kademlia {
     kad.network.Join(peer, ready)
 
     if <-ready {
+        go func() {
+            reader := bufio.NewReader(os.Stdin)
+            for {
+                row, err := reader.ReadString('\n')
+                if err != nil {
+                    println("%#v", err)
+                    continue
+                }
+                splitText := strings.Fields(row)
+
+                if len(splitText) == 1 {
+                    command := splitText[0]
+                    switch command {
+                        case "exit":
+                            os.Exit(0)
+                    }
+                } else if len(splitText) > 1 {
+                    command := splitText[0]
+                    parameter := strings.Join(splitText[1:], " ")
+                    switch command {
+                        case "put":
+                            kad.Store([]byte(parameter))
+                        case "get":
+                            kad.LookupData(parameter)
+                    }
+                }
+            }
+        } ()
         return kad
     }
     panic("Failed to join network!")
 }
 
 func (kademlia *Kademlia) LookupContact(target *Contact) {
-    emptyMap := make(map[KademliaID]struct{})
     kademlia.network.SendFindContactMessage(
         *target.ID,
-        &emptyMap,
+        func() {},
     )
 }
 
 func (kademlia *Kademlia) LookupData(hash string) {
-	// TODO
+    hashID := NewKademliaID(hash)
+    kademlia.network.SendFindDataMessage(*hashID)
 }
 
 func (kademlia *Kademlia) Store(data []byte) {
-	// TODO
+    hash := Hash(data)
+    emptyMap := make(map[KademliaID]struct{})
+    mux := sync.Mutex{}
+    done := false
+    kademlia.network.SendFindContactMessage(
+        *hash,
+        func() {
+            kademlia.network.sendStoreMessage(
+                data,
+                &emptyMap,
+                &mux,
+                &done,
+                func() {
+                    println(hash.String())
+                },
+            )
+        },
+    )
 }

--- a/labCode/kademliaid.go
+++ b/labCode/kademliaid.go
@@ -3,6 +3,7 @@ package d7024e
 import (
 	"encoding/hex"
 	"math/rand"
+    "crypto/sha512"
 )
 
 // the static number of bytes in a KademliaID
@@ -30,6 +31,17 @@ func NewRandomKademliaID() *KademliaID {
 	for i := 0; i < IDLength; i++ {
 		newKademliaID[i] = uint8(rand.Intn(256))
 	}
+	return &newKademliaID
+}
+
+func Hash(data []byte) *KademliaID {
+    hash := sha512.Sum512(data)
+
+	newKademliaID := KademliaID{}
+	for i := 0; i < IDLength; i++ {
+		newKademliaID[i] = hash[i]
+	}
+
 	return &newKademliaID
 }
 

--- a/labCode/network.go
+++ b/labCode/network.go
@@ -1,11 +1,13 @@
 package d7024e
 
 import(
+	"encoding/hex"
     "encoding/json"
     "fmt"
     "net"
     "regexp"
     "strconv"
+    "sync"
     "time"
 )
 
@@ -19,6 +21,8 @@ type Network struct {
     RoutingTable *RoutingTable
     MessageRecord MessageRecord
     Conn net.PacketConn
+    store map[KademliaID][]byte
+    mux sync.RWMutex
 }
 
 func NewNetwork(ip string, port uint16) Network {
@@ -36,6 +40,8 @@ func NewNetwork(ip string, port uint16) Network {
         RoutingTable: NewRoutingTable(me),
         MessageRecord: NewMessageRecord(),
         Conn: conn,
+        store: make(map[KademliaID][]byte),
+        mux: sync.RWMutex{},
     }
 
     go Listen(ip, port, &network)
@@ -76,11 +82,11 @@ func Listen(ip string, port uint16, network *Network) {
 }
 
 func (network *Network) Join(peer string, ready chan bool) {
-    msgID := NewRandomKademliaID().String()
+    requestID := NewRandomKademliaID()
     firstMsg := Message{
         Type : "RPC",
         Name : "PING",
-        RequestID : msgID,
+        RequestID : requestID.String(),
         Source : network.RoutingTable.me.ID.String(),
         Destination : network.RoutingTable.me.ID.String(),
         Params : []string{},
@@ -92,14 +98,18 @@ func (network *Network) Join(peer string, ready chan bool) {
         firstMsg.RequestID,
     )
 
-    emptyMap := make(map[KademliaID]struct{})
     network.MessageRecord.RecordMessage(
-        msgID,
+        *requestID,
         func(msg Message, contact Contact) {
-            fmt.Println("RX_JOIN_RES:", msg.Source, msg.Destination, msg.RequestID)
+            fmt.Println(
+                "RX_JOIN_RES:",
+                msg.Source,
+                msg.Destination,
+                msg.RequestID,
+            )
             network.SendFindContactMessage(
                 *network.RoutingTable.me.ID,
-                &emptyMap,
+                func() {},
             )
             ready <- true
         }, func() {
@@ -113,13 +123,13 @@ func (network *Network) Join(peer string, ready chan bool) {
 
 func (network *Network) SendPingMessage(
     contact *Contact,
-    onReply func(contact Contact),
+    callback func(contact Contact),
 ) {
-    msgID := NewRandomKademliaID().String()
+    requestID := NewRandomKademliaID()
     msg := Message{
         Type : "RPC",
         Name : "PING",
-        RequestID : msgID,
+        RequestID : requestID.String(),
         Source : network.RoutingTable.me.ID.String(),
         Destination : contact.ID.String(),
         Params : []string{},
@@ -128,10 +138,15 @@ func (network *Network) SendPingMessage(
     network.send(msg, contact)
 
     network.MessageRecord.RecordMessage(
-        msgID,
+        *requestID,
         func(_ Message, contact Contact) {
-            fmt.Println("RX_PING_RES:", msg.Source, msg.Destination, msg.RequestID)
-            onReply(contact)
+            fmt.Println(
+                "RX_PING_RES:",
+                msg.Source,
+                msg.Destination,
+                msg.RequestID,
+            )
+            callback(contact)
         }, func() {
             println("PING RPC failed!")
         },
@@ -154,56 +169,47 @@ func (network *Network) returnPingMessage(msg Message, contact *Contact) {
 
 func (network *Network) SendFindContactMessage(
     askFor KademliaID,
-    sentTo *map[KademliaID]struct{},
+    callback func(),
 ) {
-    sendTo := make([]*Contact, 0)
-    searchLen := 1
-    for searchLen >= bucketSize || len(sendTo) < ALPHA {
-        closeSlice := network.RoutingTable.FindClosestContacts(
-            &askFor,
-            searchLen,
-        )
+    emptyMap := make(map[KademliaID]struct{})
+    mux := sync.Mutex{}
+    done := false
+    network.sendFindContactMessage(askFor, &emptyMap, &mux, &done, callback)
+}
 
-        if len(closeSlice) < searchLen {
-            break
-        }
-
-        closeContact := closeSlice[len(closeSlice) - 1]
-        if _, ok := (*sentTo)[*closeContact.ID]; !ok {
-            sendTo = append(sendTo, &closeContact)
-            (*sentTo)[*closeContact.ID] = struct{}{}
-        }
-        searchLen++
+func (network *Network) sendFindContactMessage(
+    askFor KademliaID,
+    sentTo *map[KademliaID]struct{},
+    mux *sync.Mutex,
+    done *bool,
+    callback func(),
+) {
+    msg := Message{
+        Type: "RPC",
+        Name: "FIND-NODE",
+        Source: network.RoutingTable.me.ID.String(),
+        Params: []string{askFor.String()},
     }
-
-    // Base case
-    if searchLen >= bucketSize || len(sendTo) == 0 {
-        return
-    }
-
-    for _, to := range sendTo {
-        msgID := NewRandomKademliaID().String()
-        msg := Message{
-            Type: "RPC",
-            Name: "FIND-NODE",
-            RequestID: msgID,
-            Source: network.RoutingTable.me.ID.String(),
-            Destination: to.ID.String(),
-            Params: []string{askFor.String()},
-        }
-
-        network.MessageRecord.RecordMessage(
-            msgID,
-            func(msg Message, contact Contact) {
-                network.handleFindContactMessage(msg, &contact, askFor, sentTo)
-            }, func() {
-                network.SendFindContactMessage(askFor, sentTo)
-            },
-        )
-
-        fmt.Println("TX_FIND_RPC:", msg.Source, msg.Destination, msg.RequestID)
-        network.send(msg, to)
-    }
+    network.recurseMsg(
+        &askFor,
+        msg,
+        sentTo,
+        mux,
+        done,
+        "FIND",
+        func(msg Message, contact Contact) {
+            network.handleFindContactMessage(
+                msg,
+                &contact,
+                askFor,
+                sentTo,
+                mux,
+                done,
+                callback,
+            )
+        },
+        callback,
+    )
 }
 
 func (network *Network) returnFindContactMessage(
@@ -213,6 +219,7 @@ func (network *Network) returnFindContactMessage(
     fmt.Println("RX_FIND_RPC:", msg.Source, msg.Destination, msg.RequestID)
     if len(msg.Params) != 1 {
         println("Malformed FIND-NODE message!")
+        return
     }
 
     response := Message{
@@ -240,6 +247,9 @@ func (network *Network) handleFindContactMessage(
     contact *Contact,
     askFor KademliaID,
     sentTo *map[KademliaID]struct{},
+    mux *sync.Mutex,
+    done *bool,
+    callback func(),
 ) {
     fmt.Println("RX_FIND_RES:", msg.Source, msg.Destination, msg.RequestID)
     params := msg.Params
@@ -257,32 +267,223 @@ func (network *Network) handleFindContactMessage(
         network.RoutingTable.AddContact(newContact)
     }
 
-    network.SendFindContactMessage(askFor, sentTo)
+    network.sendFindContactMessage(askFor, sentTo, mux, done, callback)
 }
 
 
-func (network *Network) SendFindDataMessage(hash string) {
-	// TODO
+func (network *Network) SendStoreMessage(data []byte, callback func()) {
+    emptyMap := make(map[KademliaID]struct{})
+    mux := sync.Mutex{}
+    done := false
+    network.sendStoreMessage(data, &emptyMap, &mux, &done, callback)
 }
 
-func (network *Network) SendStoreMessage(data []byte) {
-	// TODO
-}
-
-func (network *Network) returnFindDataMessage(msg Message, contact *Contact) {
-	// TODO
+func (network *Network) sendStoreMessage(
+    data []byte,
+    sentTo *map[KademliaID]struct{},
+    mux *sync.Mutex,
+    done *bool,
+    callback func(),
+) {
+    hash := Hash(data)
+    msg := Message{
+        Type: "RPC",
+        Name: "STORE",
+        Source: network.RoutingTable.me.ID.String(),
+        Params: []string{hash.String(), hex.EncodeToString(data)},
+    }
+    network.recurseMsg(
+        hash,
+        msg,
+        sentTo,
+        mux,
+        done,
+        "STOR",
+        func(msg Message, contact Contact) {
+            network.handleStoreMessage(
+                msg,
+                &contact,
+                data,
+                sentTo,
+                mux,
+                done,
+                callback,
+            )
+        },
+        callback,
+    )
 }
 
 func (network *Network) returnStoreMessage(msg Message, contact *Contact) {
-	// TODO
+    fmt.Println("RX_STOR_RPC:", msg.Source, msg.Destination, msg.RequestID)
+    if len(msg.Params) != 2 {
+        println("Malformed STORE message!")
+        return
+    }
+
+    response := Message{
+        Type: "RETURN",
+        Name: "STORE",
+        RequestID: msg.RequestID,
+        Source: network.RoutingTable.me.ID.String(),
+        Destination: contact.ID.String(),
+        Params: []string{},
+    }
+
+    data, err := hex.DecodeString(msg.Params[1])
+    if err != nil {
+        println("%#v", err)
+        return
+    }
+    hash := NewKademliaID(msg.Params[0])
+    network.mux.Lock()
+    network.store[*hash] = data
+    network.mux.Unlock()
+
+    fmt.Println("TX_STOR_RES:", msg.Source, msg.Destination, msg.RequestID)
+    network.send(response, contact)
 }
 
-func (network *Network) handleFindDataMessage(msg Message, contact *Contact) {
-	// TODO
+func (network *Network) handleStoreMessage(
+    msg Message,
+    contact *Contact,
+    data []byte,
+    sentTo *map[KademliaID]struct{},
+    mux *sync.Mutex,
+    done *bool,
+    callback func(),
+) {
+    fmt.Println("RX_STOR_RES:", msg.Source, msg.Destination, msg.RequestID)
+    params := msg.Params
+    if len(params) != 0 {
+        println("Malformed STORE response!")
+        return
+    }
+
+    network.sendStoreMessage(data, sentTo, mux, done, callback)
 }
 
-func (network *Network) handleStoreMessage(msg Message, contact *Contact) {
-    // TODO
+func (network *Network) SendFindDataMessage(
+    askFor KademliaID,
+) {
+    emptyMap := make(map[KademliaID]struct{})
+    mux := sync.Mutex{}
+    done := false
+    network.sendFindDataMessage(askFor, &emptyMap, &mux, &done)
+}
+
+func (network *Network) sendFindDataMessage(
+    askFor KademliaID,
+    sentTo *map[KademliaID]struct{},
+    mux *sync.Mutex,
+    done *bool,
+) {
+    msg := Message{
+        Type: "RPC",
+        Name: "FIND-VALUE",
+        Source: network.RoutingTable.me.ID.String(),
+        Params: []string{askFor.String()},
+    }
+    network.recurseMsg(
+        &askFor,
+        msg,
+        sentTo,
+        mux,
+        done,
+        "FVAL",
+        func(msg Message, contact Contact) {
+            network.handleFindDataMessage(
+                msg,
+                &contact,
+                askFor,
+                sentTo,
+                mux,
+                done,
+            )
+        },
+        func() {},
+    )
+}
+
+func (network *Network) returnFindDataMessage(msg Message, contact *Contact) {
+    fmt.Println("RX_FVAL_RPC:", msg.Source, msg.Destination, msg.RequestID)
+    if len(msg.Params) != 1 {
+        println("Malformed FIND-VALUE message!")
+        return
+    }
+
+    response := Message{
+        Type: "RETURN",
+        Name: "FIND-VALUE",
+        RequestID: msg.RequestID,
+        Source: network.RoutingTable.me.ID.String(),
+        Destination: contact.ID.String(),
+    }
+
+    asksFor := NewKademliaID(msg.Params[0])
+    contacts := network.RoutingTable.FindClosestContacts(asksFor, bucketSize)
+
+    ID := NewKademliaID(msg.Params[0])
+    network.mux.RLock()
+    value, ok := network.store[*ID]
+    network.mux.RUnlock()
+    if ok {
+        response.Params = []string{
+            hex.EncodeToString(value),
+        }
+    } else {
+        contactList := make([]string, 0)
+        for i := 0; i < len(contacts); i++ {
+            contactList = append(contactList, contacts[i].ID.String())
+            contactList = append(contactList, contacts[i].Address)
+        }
+        response.Params = contactList
+    }
+
+    fmt.Println("TX_FVAL_RES:", msg.Source, msg.Destination, msg.RequestID)
+    network.send(response, contact)
+}
+
+func (network *Network) handleFindDataMessage(
+    msg Message,
+    contact *Contact,
+    askFor KademliaID,
+    sentTo *map[KademliaID]struct{},
+    mux *sync.Mutex,
+    done *bool,
+) {
+    fmt.Println("RX_FVAL_RES:", msg.Source, msg.Destination, msg.RequestID)
+    params := msg.Params
+    if len(params) == 0 || (len(params) % 2 == 1 && len(params) != 1) {
+        println("Malformed FIND-VALUE response!")
+        return
+    }
+
+    if len(params) == 1 {
+        mux.Lock()
+        if !*done {
+            data, err := hex.DecodeString(msg.Params[0])
+            if err != nil {
+                println("%#v", err)
+                return
+            }
+            println(string(data))
+            *done = true
+        }
+        mux.Unlock()
+        return
+    }
+
+    var newContacts []Contact
+    for i := 0; i < len(params); i = i + 2 {
+        newID := params[i]
+        newAddress := params[i + 1]
+        newContact := NewContact(NewKademliaID(newID), newAddress)
+        newContacts = append(newContacts, newContact)
+        network.RoutingTable.AddContact(newContact)
+    }
+
+    network.sendFindDataMessage(askFor, sentTo, mux, done)
 }
 
 func routeMsg(msg Message, contact *Contact, network *Network) {
@@ -322,3 +523,76 @@ func (network *Network) send(msg Message, contact *Contact) {
     }
 }
 
+func (network *Network) recurseMsg(
+    askFor *KademliaID,
+    origMsg Message,
+    sentTo *map[KademliaID]struct{},
+    mux *sync.Mutex,
+    done *bool,
+    log_name string,
+    handler func(msg Message, contact Contact),
+    callback func(),
+) {
+    sendTo := make([]*Contact, 0)
+    searchLen := 1
+    for searchLen <= bucketSize && len(sendTo) < ALPHA {
+        closeSlice := network.RoutingTable.FindClosestContacts(
+            askFor,
+            searchLen,
+        )
+
+        if len(closeSlice) < searchLen {
+            break
+        }
+
+        closeContact := closeSlice[len(closeSlice) - 1]
+        mux.Lock()
+        if _, ok := (*sentTo)[*closeContact.ID]; !ok {
+            sendTo = append(sendTo, &closeContact)
+            (*sentTo)[*closeContact.ID] = struct{}{}
+        }
+        mux.Unlock()
+        searchLen++
+    }
+
+    // Base case
+    if len(sendTo) == 0 {
+        if !*done {
+            *done = true
+            callback()
+        }
+        return
+    }
+
+    for _, to := range sendTo {
+        msg := origMsg
+        requestID := NewRandomKademliaID()
+        msg.RequestID = requestID.String()
+        msg.Destination = to.ID.String()
+
+        network.MessageRecord.RecordMessage(
+            *requestID,
+            handler,
+            func() {
+                network.recurseMsg(
+                    askFor,
+                    origMsg,
+                    sentTo,
+                    mux,
+                    done,
+                    log_name,
+                    handler,
+                    callback,
+                )
+            },
+        )
+
+        fmt.Println(
+            "TX_" + log_name + "_RPC:",
+            msg.Source,
+            msg.Destination,
+            msg.RequestID,
+        )
+        network.send(msg, to)
+    }
+}


### PR DESCRIPTION
Pipes the log/stdout to a file last.log, so that the only output on the
prompt is stderr and stdin.

The prompt supports the commands put get and exit. I have tested that
nodes without a value stored on them can fetch them on command.

Known bug: Currently does not force parallelism to cap at ALPHA,
it caps forking to ALPHA, leading to an exponential increase in
running goroutines. This is not a problem on small networks though.

#6 #7 #8